### PR TITLE
Code changes through visual studio

### DIFF
--- a/AutoKoanRunner/Program.cs
+++ b/AutoKoanRunner/Program.cs
@@ -29,8 +29,8 @@ namespace AutoKoanRunner
 			{
 				Array.ForEach(watchers, w =>
 				{
-					w.Changed += StartRunner;
-					w.NotifyFilter = NotifyFilters.LastWrite;
+                    w.Changed += StartRunner;
+                    w.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime;
 					w.EnableRaisingEvents = true;
 				});
 


### PR DESCRIPTION
When changing code in the koans inside Visual studio 2013 the runner wasn't getting triggered. 
This is due to visual studio not directly editing files, instead it creates temporary files and then deletes them. 
Adding NotifyFilters.CreationTime fixed the issue for me.

+info:
- http://stackoverflow.com/questions/680698/why-doesnt-filesystemwatcher-detect-changes-from-visual-studio
- http://stackoverflow.com/questions/19905151/system-io-filesystemwatcher-does-not-watch-file-changed-by-visual-studio-2013
